### PR TITLE
introduce lib.mkFlake

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,15 @@ Otherwise, add the input,
     flake-modules-core.inputs.nixpkgs.follows = "nixpkgs";
 ```
 
-then slide `evalFlakeModule` between your outputs function head and body,
+then slide `mkFlake` between your outputs function head and body,
 
 ```
   outputs = { self, flake-modules-core, ... }:
-    (flake-modules-core.lib.evalFlakeModule
-      { inherit self; }
-      {
-        flake = {
-          # Put your original flake attributes here.
-        }
+    flake-modules-core.lib.mkFlake { inherit self; } {
+      flake = {
+        # Put your original flake attributes here.
       }
-    ).config.flake;
+    };
 ```
 
 Now you can add the remaining module attributes like in the [the template](./template/default/flake.nix).

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,5 @@
+status = [
+  "ci/hercules/onPush/default",
+  "ci/hercules/evaluation",
+]
+delete_merged_branches = true

--- a/lib.nix
+++ b/lib.nix
@@ -38,6 +38,9 @@ let
         modules = [ ./all-modules.nix module ];
       };
 
+    mkFlake = args: module:
+      (flake-modules-core-lib.evalFlakeModule args module).config.flake;
+
     # For extending options in an already declared submodule.
     # Workaround for https://github.com/NixOS/nixpkgs/issues/146882
     mkSubmoduleOptions =

--- a/template/default/flake.nix
+++ b/template/default/flake.nix
@@ -8,7 +8,7 @@
   };
 
   outputs = { self, flake-modules-core, ... }:
-    flake-modules-core.mkFlake { inherit self; } {
+    flake-modules-core.lib.mkFlake { inherit self; } {
       imports = [
         # To import a flake module
         # 1. Add foo to inputs

--- a/template/default/flake.nix
+++ b/template/default/flake.nix
@@ -8,31 +8,28 @@
   };
 
   outputs = { self, flake-modules-core, ... }:
-    (flake-modules-core.lib.evalFlakeModule
-      { inherit self; }
-      {
-        imports = [
-          # To import a flake module
-          # 1. Add foo to inputs
-          # 2. Add foo as a parameter to the outputs function
-          # 3. Add here: foo.flakeModule
+    flake-modules-core.mkFlake { inherit self; } {
+      imports = [
+        # To import a flake module
+        # 1. Add foo to inputs
+        # 2. Add foo as a parameter to the outputs function
+        # 3. Add here: foo.flakeModule
 
-        ];
-        systems = [ "x86_64-linux" "aarch64-darwin" ];
-        perSystem = system: { config, self', inputs', pkgs, ... }: {
-          # Per-system attributes can be defined here. The self' and inputs'
-          # module parameters provide easy access to attributes of the same
-          # system.
+      ];
+      systems = [ "x86_64-linux" "aarch64-darwin" ];
+      perSystem = system: { config, self', inputs', pkgs, ... }: {
+        # Per-system attributes can be defined here. The self' and inputs'
+        # module parameters provide easy access to attributes of the same
+        # system.
 
-          # Equivalent to  inputs'.nixpkgs.legacyPackages.hello;
-          packages.hello = pkgs.hello;
-        };
-        flake = {
-          # The usual flake attributes can be defined here, including system-
-          # agnostic ones like nixosModule and system-enumerating ones, although
-          # those are more easily expressed in perSystem.
+        # Equivalent to  inputs'.nixpkgs.legacyPackages.hello;
+        packages.hello = pkgs.hello;
+      };
+      flake = {
+        # The usual flake attributes can be defined here, including system-
+        # agnostic ones like nixosModule and system-enumerating ones, although
+        # those are more easily expressed in perSystem.
 
-        };
-      }
-    ).config.flake;
+      };
+    };
 }

--- a/template/multi-module/flake.nix
+++ b/template/multi-module/flake.nix
@@ -8,26 +8,23 @@
   };
 
   outputs = { self, flake-modules-core, ... }:
-    (flake-modules-core.lib.evalFlakeModule
-      { inherit self; }
-      {
-        imports = [
-          ./hello/flake-module.nix
-        ];
-        systems = [ "x86_64-linux" "aarch64-darwin" ];
-        perSystem = system: { config, self', inputs', ... }: {
-          # Per-system attributes can be defined here. The self' and inputs'
-          # module parameters provide easy access to attributes of the same
-          # system.
+    flake-modules-core.lib.mkFlake { inherit self; } {
+      imports = [
+        ./hello/flake-module.nix
+      ];
+      systems = [ "x86_64-linux" "aarch64-darwin" ];
+      perSystem = system: { config, self', inputs', ... }: {
+        # Per-system attributes can be defined here. The self' and inputs'
+        # module parameters provide easy access to attributes of the same
+        # system.
 
-          packages.figlet = inputs'.nixpkgs.legacyPackages.figlet;
-        };
-        flake = {
-          # The usual flake attributes can be defined here, including system-
-          # agnostic ones like nixosModule and system-enumerating ones, although
-          # those are more easily expressed in perSystem.
+        packages.figlet = inputs'.nixpkgs.legacyPackages.figlet;
+      };
+      flake = {
+        # The usual flake attributes can be defined here, including system-
+        # agnostic ones like nixosModule and system-enumerating ones, although
+        # those are more easily expressed in perSystem.
 
-        };
-      }
-    ).config.flake;
+      };
+    };
 }


### PR DESCRIPTION
This makes the most common use-case a tiny bit less verbose.

I didn't name it mkFlakeModule because it would be redundant with the project name.