### PR TITLE
Change doc path for eg. `flake.apps.<name>.<name>.*` to `flake.apps.<system>.<name>.*`

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -174,7 +174,11 @@ let
       options = {
         flake = flake-parts-lib.mkSubmoduleOptions {
           ${name} = mkOption {
-            type = types.lazyAttrsOf option.type;
+            type = types.attrsWith {
+              elemType = option.type;
+              lazy = true;
+              placeholder = "system";
+            };
             default = { };
             description = ''
               See {option}`perSystem.${name}` for description and examples.


### PR DESCRIPTION
Adding "placeholder" parameter to the attrs type allows changing the name that shows up in the docs. Since we have two `<name>` placeholders in a row, this adds clarity here.

<img width="1027" height="250" alt="image" src="https://github.com/user-attachments/assets/b216a6fb-d148-40f7-962b-4e263bbfb8a8" />

I have tested it in my own project (which has it's own options rendering) via `optionsCommonMark`