### PR TITLE
docs: Show equivalent for partitionedAttrs

### DIFF
--- a/extras/partitions.nix
+++ b/extras/partitions.nix
@@ -105,6 +105,10 @@ in
         The flake attributes are overridden with `lib.mkForce` priority.
 
         See the `partitions` options to understand the purpose.
+
+        Example: `partitionedAttrs.devShells = "dev";`
+
+        Equivalent: `flake.devShells = lib.mkForce config.partitions.dev.module.flake.devShells;`
       '';
       example = {
         "devShells" = "dev";


### PR DESCRIPTION
Add a concise example showing what partitionedAttrs expands to, making it clearer how the shorthand relates to the underlying implementation.