### PR TITLE
dev/flake-module: delegate pre-commit installation to upstream

### DIFF
--- a/dev/flake-module.nix
+++ b/dev/flake-module.nix
@@ -22,11 +22,10 @@
     devShells.default = pkgs.mkShell {
       nativeBuildInputs = [
         pkgs.nixpkgs-fmt
-        pkgs.pre-commit
         pkgs.hci
       ];
       shellHook = ''
-        ${config.pre-commit.installationScript}
+        ${config.pre-commit.shellHook}
       '';
     };
 


### PR DESCRIPTION
```
Fixes: fcf9d5234bea ("dev: Add pre-commit-hooks.nix")
```

As per https://github.com/cachix/git-hooks.nix/commit/d665a44b7c3bcf6a2054c4e7876b6077f714e843, this appends

```diff
+
+export PATH=/nix/store/hhzpwcr2r29603ygc147wr58vlkf4qv5-pre-commit-4.5.0/bin:$PATH
```

to

```console
nix eval .#devShells.x86_64-linux.default.shellHook
```

This PR is very similar to https://github.com/nix-community/stylix/pull/2136.
