### PR TITLE
Gives value to `key` attribute of modules composed via `flake.modules`.

### DIFF
--- a/extras/modules.nix
+++ b/extras/modules.nix
@@ -22,6 +22,7 @@ let
       { ... }:
       {
         # TODO: set key?
+        key = "${class}.${escapeNixIdentifier moduleName}";
         _class = class;
         _file = "${toString moduleLocation}#modules.${escapeNixIdentifier class}.${escapeNixIdentifier moduleName}";
         imports = [ module ];


### PR DESCRIPTION
This is my first PR ever! So I don't really know how to document all of this.

The entire discussion and motivation behind this one-line-change PR can be read in #299.

Basically, in scenarios where modules composed via the `flake.modules.class.name` option end up creating diamond dependencies, de-duplication breaks. This is because (for reasons that I don't know) `key` is not set to some appropriate value. 

Please refer to the entire explanation behind the change that this PR introduces [here](https://github.com/hercules-ci/flake-parts/issues/299#issuecomment-3862443945).

Like I said in [my explanation](https://github.com/hercules-ci/flake-parts/issues/299#issuecomment-3862443945), I'm not familiarized with all of flake-parts' particularities and cannot determine if this breaks any existing functionality. Please let me know if that's the case, and I'll attempt my best to fix it.